### PR TITLE
fix(engine): Split npc_changetype() into npc_changetype_keepall()

### DIFF
--- a/data/src/scripts/engine.rs2
+++ b/data/src/scripts/engine.rs2
@@ -601,6 +601,8 @@
 [command,.npc_tele](coord $coord)
 // info: Change the npc's current type - new npc properties will be inherited
 [command,npc_changetype](npc $type, int $duration)
+// info: Change the npc's current type - new npc properties will be inherited
+[command,npc_changetype_keepall](npc $type, int $duration)
 // info: Return the current npc's ai mode
 [command,npc_getmode]()(npc_mode)
 // info: Return the secondary npc's ai mode

--- a/src/engine/World.ts
+++ b/src/engine/World.ts
@@ -679,7 +679,7 @@ class World {
                 }
 
                 // - Npc Events (Respawn, Revert, Despawn)
-                if (npc.lifecycleTick > -1 && npc.lifecycleTick < this.currentTick) {
+                if (npc.lifecycleTick > -1 && npc.lifecycleTick <= this.currentTick) {
                     try {
                         // Respawn NPC
                         if (npc.lifecycle === EntityLifeCycle.RESPAWN && !npc.isActive) {
@@ -1040,9 +1040,7 @@ class World {
             player.reorient();
             player.buildArea.rebuildNormal(); // set origin before compute player is why this is above.
 
-            const appearance = player.masks & PlayerInfoProt.APPEARANCE
-                ? player.generateAppearance()
-                : player.lastAppearanceBytes ?? player.generateAppearance();
+            const appearance = player.masks & PlayerInfoProt.APPEARANCE ? player.generateAppearance() : (player.lastAppearanceBytes ?? player.generateAppearance());
 
             rsbuf.computePlayer(
                 player.x,
@@ -1085,7 +1083,7 @@ class World {
                 player.exactEndZ,
                 player.exactMoveStart,
                 player.exactMoveEnd,
-                player.exactMoveDirection,
+                player.exactMoveDirection
             );
         }
 
@@ -1116,7 +1114,7 @@ class World {
                 npc.chat,
                 npc.graphicId,
                 npc.graphicHeight,
-                npc.graphicDelay,
+                npc.graphicDelay
             );
         }
     }
@@ -1196,10 +1194,6 @@ class World {
 
         // - reset npcs
         for (const npc of this.npcs) {
-            if (!npc.isActive) {
-                continue;
-            }
-
             npc.resetEntity(false);
         }
 
@@ -1353,7 +1347,9 @@ class World {
             this.npcEventQueue.addTail(new NpcEventRequest(NpcEventType.SPAWN, script, npc));
         }
 
-        npc.setLifeCycle(this.currentTick + duration);
+        if (duration > -1) {
+            npc.setLifeCycle(this.currentTick + duration);
+        }
     }
 
     removeNpc(npc: Npc, duration: number): void {
@@ -1376,7 +1372,7 @@ class World {
             rsbuf.removeNpc(npc.nid);
             this.npcs.remove(npc.nid);
             npc.cleanup();
-        } else if (npc.lifecycle === EntityLifeCycle.RESPAWN) {
+        } else if (npc.lifecycle === EntityLifeCycle.RESPAWN && duration > -1) {
             npc.setLifeCycle(this.currentTick + adjustedDuration);
         }
     }

--- a/src/engine/entity/Npc.ts
+++ b/src/engine/entity/Npc.ts
@@ -66,6 +66,7 @@ export default class Npc extends PathingEntity {
     nextPatrolTick: number = -1;
     nextPatrolPoint: number = 0;
     delayedPatrol: boolean = false;
+    resetOnRevert: boolean = true;
 
     lastWanderTick: number = 0;
 
@@ -152,8 +153,10 @@ export default class Npc extends PathingEntity {
             this.huntMode = npcType.huntmode;
             this.huntClock = 0;
             this.huntTarget = null;
+            this.tele = true;
+        } else {
+            super.resetPathingEntity();
         }
-        super.resetPathingEntity();
     }
 
     pathToPathingTarget(): void {
@@ -1008,23 +1011,31 @@ export default class Npc extends PathingEntity {
         return this.currentType;
     }
 
-    changeType(type: number, duration: number) {
+    changeType(type: number, duration: number, reset: boolean = true) {
         if (!this.isActive || duration < 1) {
             return;
         }
         this.currentType = type;
         this.masks |= NpcInfoProt.CHANGE_TYPE;
         this.uid = (type << 16) | this.nid;
+        this.resetOnRevert = reset;
 
-        this.setLifeCycle(World.currentTick + duration);
+        if (type === this.baseType) {
+            this.setLifeCycle(-1);
+        } else {
+            this.setLifeCycle(World.currentTick + duration);
+        }
     }
 
     revert(): void {
-        this.currentType = this.baseType;
-        this.masks |= NpcInfoProt.CHANGE_TYPE;
-        this.uid = (this.type << 16) | this.nid;
-
-        this.setLifeCycle(-1);
+        if (this.resetOnRevert) {
+            World.removeNpc(this, -1);
+            World.addNpc(this, -1);
+        } else {
+            this.currentType = this.baseType;
+            this.masks |= NpcInfoProt.CHANGE_TYPE;
+            this.uid = (this.type << 16) | this.nid;
+        }
     }
 
     isValid(_hash64?: bigint): boolean {

--- a/src/engine/script/ScriptOpcode.ts
+++ b/src/engine/script/ScriptOpcode.ts
@@ -212,6 +212,7 @@ enum ScriptOpcode {
     NPC_BASESTAT, // official
     NPC_CATEGORY, // official
     NPC_CHANGETYPE,
+    NPC_CHANGETYPE_KEEPALL,
     NPC_COORD, // official
     NPC_DAMAGE,
     NPC_DEL, // official

--- a/src/engine/script/ScriptOpcodePointers.ts
+++ b/src/engine/script/ScriptOpcodePointers.ts
@@ -534,6 +534,10 @@ const ScriptOpcodePointers: {
         require: ['active_npc'],
         require2: ['active_npc2']
     },
+    [ScriptOpcode.NPC_CHANGETYPE_KEEPALL]: {
+        require: ['active_npc'],
+        require2: ['active_npc2']
+    },
     [ScriptOpcode.NPC_COORD]: {
         require: ['active_npc'],
         require2: ['active_npc2']

--- a/src/engine/script/handlers/NpcOps.ts
+++ b/src/engine/script/handlers/NpcOps.ts
@@ -396,6 +396,14 @@ const NpcOps: CommandHandlers = {
         state.activeNpc.changeType(npcType, duration);
     }),
 
+    [ScriptOpcode.NPC_CHANGETYPE_KEEPALL]: checkedHandler(ActiveNpc, state => {
+        const [id, duration] = state.popInts(2);
+        const npcType: number = check(id, NpcTypeValid).id;
+        check(duration, DurationValid);
+
+        state.activeNpc.changeType(npcType, duration);
+    }),
+
     [ScriptOpcode.NPC_GETMODE]: checkedHandler(ActiveNpc, state => {
         state.pushInt(state.activeNpc.targetOp);
     }),

--- a/src/engine/script/handlers/NpcOps.ts
+++ b/src/engine/script/handlers/NpcOps.ts
@@ -401,7 +401,7 @@ const NpcOps: CommandHandlers = {
         const npcType: number = check(id, NpcTypeValid).id;
         check(duration, DurationValid);
 
-        state.activeNpc.changeType(npcType, duration);
+        state.activeNpc.changeType(npcType, duration, false);
     }),
 
     [ScriptOpcode.NPC_GETMODE]: checkedHandler(ActiveNpc, state => {


### PR DESCRIPTION
Two diff engine commands now

keepall will not reset npc when it reverts. the normal command will do a soft 'respawn' of the npc when it reverts type